### PR TITLE
refactor: photoReferenceを削除しphotoReferencesに統一 (#49)

### DIFF
--- a/ShishaMap/Features/Detail/StoreDetailView.swift
+++ b/ShishaMap/Features/Detail/StoreDetailView.swift
@@ -52,9 +52,7 @@ struct StoreDetailView: View {
     // MARK: - 写真
 
     private var storePhoto: some View {
-        let refs = store.photoReferences.isEmpty
-            ? (store.photoReference.map { [$0] } ?? [])
-            : store.photoReferences
+        let refs = store.photoReferences
         return Group {
             if refs.isEmpty {
                 photoPlaceholder

--- a/ShishaMap/Models/Store.swift
+++ b/ShishaMap/Models/Store.swift
@@ -14,7 +14,10 @@ final class Store {
     var flavors: [String]
     var priceLevel: Int?
     var hasPrivateRoom: Bool
-    var photoReference: String?
+    var photoReferences: [String] = []
+    var websiteURL: String?
+    var rating: Double?
+    var userRatingsTotal: Int?
     var isOpenNow: Bool
     var isFavorite: Bool
     @Relationship(deleteRule: .cascade) var checkIns: [CheckIn]
@@ -36,6 +39,7 @@ final class Store {
         self.hasPrivateRoom = hasPrivateRoom
         self.flavors = flavors
         self.openingHours = []
+        self.photoReferences = []
         self.isOpenNow = false
         self.isFavorite = false
         self.checkIns = []
@@ -43,6 +47,12 @@ final class Store {
 
     var coordinate: CLLocationCoordinate2D {
         CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+
+    /// 店名にシーシャ関連キーワードを含む場合を専門店とみなす
+    var isShishaSpecialty: Bool {
+        let keywords = ["シーシャ", "水煙草", "水タバコ", "hookah", "shisha", "HOOKAH", "SHISHA"]
+        return keywords.contains { name.localizedCaseInsensitiveContains($0) }
     }
 
     var priceLevelText: String? {
@@ -59,8 +69,8 @@ final class Store {
 }
 
 extension Store {
-    static let mocks: [Store] = [
-        Store(
+    static let mocks: [Store] = {
+        let tokyo = Store(
             placeID: "mock_001",
             name: "シーシャ東京",
             address: "渋谷区道玄坂1-1",
@@ -68,8 +78,23 @@ extension Store {
             longitude: 139.7016,
             hasPrivateRoom: true,
             flavors: ["フルーツ系", "ミント系"]
-        ),
-        Store(
+        )
+        tokyo.isOpenNow = true
+        tokyo.rating = 4.3
+        tokyo.userRatingsTotal = 128
+        tokyo.phoneNumber = "03-1234-5678"
+        tokyo.websiteURL = "https://example.com/shisha-tokyo"
+        tokyo.openingHours = [
+            "月曜日: 17:00 – 翌2:00",
+            "火曜日: 17:00 – 翌2:00",
+            "水曜日: 17:00 – 翌2:00",
+            "木曜日: 17:00 – 翌2:00",
+            "金曜日: 17:00 – 翌3:00",
+            "土曜日: 14:00 – 翌3:00",
+            "日曜日: 14:00 – 翌2:00"
+        ]
+
+        let hookah = Store(
             placeID: "mock_002",
             name: "HOOKAH LOUNGE",
             address: "新宿区歌舞伎町2-2",
@@ -77,8 +102,11 @@ extension Store {
             longitude: 139.7034,
             hasPrivateRoom: false,
             flavors: ["スパイス系"]
-        ),
-        Store(
+        )
+        hookah.rating = 3.8
+        hookah.userRatingsTotal = 54
+
+        let roppongi = Store(
             placeID: "mock_003",
             name: "シーシャバー六本木",
             address: "港区六本木3-3",
@@ -87,7 +115,12 @@ extension Store {
             hasPrivateRoom: true,
             flavors: ["フルーツ系", "フローラル系"]
         )
-    ]
+        roppongi.rating = 4.6
+        roppongi.userRatingsTotal = 312
+        roppongi.phoneNumber = "03-9876-5432"
+
+        return [tokyo, hookah, roppongi]
+    }()
 
     static var mock: Store { mocks[0] }
 }

--- a/ShishaMap/Repositories/PlacesRepository.swift
+++ b/ShishaMap/Repositories/PlacesRepository.swift
@@ -267,7 +267,6 @@ private extension Store {
         )
         self.priceLevel = result.priceLevel
         self.photoReferences = result.photos?.map { $0.photoReference } ?? []
-        self.photoReference = self.photoReferences.first
         self.isOpenNow = result.openingHours?.openNow ?? false
     }
 
@@ -286,7 +285,6 @@ private extension Store {
         self.openingHours = detail.openingHours?.weekdayText ?? []
         self.isOpenNow = detail.openingHours?.openNow ?? false
         self.photoReferences = detail.photos?.map { $0.photoReference } ?? []
-        self.photoReference = self.photoReferences.first
         self.priceLevel = detail.priceLevel
         self.rating = detail.rating
         self.userRatingsTotal = detail.userRatingsTotal

--- a/ShishaMap/ViewModels/StoreViewModel.swift
+++ b/ShishaMap/ViewModels/StoreViewModel.swift
@@ -110,7 +110,6 @@ final class StoreViewModel {
             if let website = detail.websiteURL { store.websiteURL = website }
             if !detail.photoReferences.isEmpty {
                 store.photoReferences = detail.photoReferences
-                store.photoReference = detail.photoReferences.first
             }
             if let price = detail.priceLevel { store.priceLevel = price }
             if let r = detail.rating { store.rating = r }
@@ -141,7 +140,6 @@ final class StoreViewModel {
             existing.longitude = store.longitude
             existing.isOpenNow = store.isOpenNow
             if let price = store.priceLevel { existing.priceLevel = price }
-            if let ref = store.photoReference { existing.photoReference = ref }
             if !store.photoReferences.isEmpty { existing.photoReferences = store.photoReferences }
             if !store.flavors.isEmpty { existing.flavors = store.flavors }
             return existing


### PR DESCRIPTION
## Summary
- `Store.photoReference: String?`（単数）を削除し、`photoReferences: [String]`に一本化
- PlacesRepository、StoreViewModel、StoreDetailViewの冗長な二重代入・フォールバックを削除

## Test plan
- [x] xcodebuildビルド成功確認
- [ ] シミュレータで店舗詳細画面の写真表示確認

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)