### PR TITLE
feat: os.Loggerによる本番環境ログ制御を導入

### DIFF
--- a/ShishaMap/AppLogger.swift
+++ b/ShishaMap/AppLogger.swift
@@ -1,0 +1,17 @@
+import OSLog
+
+/// カテゴリ別のos.Loggerインスタンスを提供する。
+/// リリースビルドでは `.debug` レベルのログが自動的に抑制される（os_log の標準動作）。
+/// 機密情報（APIキー・座標・ユーザーデータ）は絶対にログに含めないこと。
+enum AppLogger {
+    /// API通信関連のログ
+    static let api = Logger(subsystem: subsystem, category: "API")
+    /// ViewModel・ビジネスロジック関連のログ
+    static let viewModel = Logger(subsystem: subsystem, category: "ViewModel")
+    /// SwiftData・永続化関連のログ
+    static let data = Logger(subsystem: subsystem, category: "Data")
+    /// 位置情報関連のログ
+    static let location = Logger(subsystem: subsystem, category: "Location")
+
+    private static let subsystem = Bundle.main.bundleIdentifier ?? "com.shishamap"
+}

--- a/ShishaMap/Repositories/PlacesRepository.swift
+++ b/ShishaMap/Repositories/PlacesRepository.swift
@@ -1,5 +1,6 @@
 import CoreLocation
 import Foundation
+import OSLog
 
 final class PlacesRepository: StoreRepositoryProtocol {
     private let apiKey: String
@@ -14,8 +15,13 @@ final class PlacesRepository: StoreRepositoryProtocol {
         #if DEBUG
         guard !apiKey.isEmpty else { throw AppError.apiKeyMissing }
         #else
-        guard !apiKey.isEmpty else { return [] }
+        guard !apiKey.isEmpty else {
+            AppLogger.api.error("APIキーが未設定のためfetchNearbyをスキップ")
+            return []
+        }
         #endif
+
+        AppLogger.api.debug("fetchNearby開始 radius=\(Int(radius))m")
 
         let cacheKey = "\(coordinate.latitude),\(coordinate.longitude),\(radius)" as NSString
         if let entry = cache.object(forKey: cacheKey), entry.isValid {
@@ -69,15 +75,18 @@ final class PlacesRepository: StoreRepositoryProtocol {
             .filter { seen.insert($0.placeId).inserted }
             .map { Store(from: $0) }
 
+        AppLogger.api.debug("fetchNearby完了 \(stores.count)件取得")
         cache.setObject(CacheEntry(stores: stores), forKey: cacheKey)
         return stores
     }
 
     func fetchDetail(placeID: String) async throws -> Store {
+        AppLogger.api.debug("fetchDetail開始 placeID=\(placeID, privacy: .private)")
         #if DEBUG
         guard !apiKey.isEmpty else { throw AppError.apiKeyMissing }
         #else
         guard !apiKey.isEmpty else {
+            AppLogger.api.error("APIキーが未設定のためfetchDetailに失敗")
             throw AppError.unknown(NSError(domain: "PlacesRepository", code: -1))
         }
         #endif
@@ -107,6 +116,7 @@ final class PlacesRepository: StoreRepositoryProtocol {
         try validateAPIStatus(decoded.status)
 
         let store = Store(from: decoded.result, placeID: placeID)
+        AppLogger.api.debug("fetchDetail完了 placeID=\(placeID, privacy: .private)")
         cache.setObject(CacheEntry(stores: [store]), forKey: cacheKey)
         return store
     }
@@ -117,10 +127,18 @@ final class PlacesRepository: StoreRepositoryProtocol {
         guard let http = response as? HTTPURLResponse else { return }
         switch http.statusCode {
         case 200: break
-        case 429: throw AppError.rateLimitExceeded
-        case 401, 403: throw AppError.apiKeyMissing
-        case 400..<500: throw AppError.unknown(NSError(domain: "Places", code: http.statusCode))
-        case 500...: throw AppError.networkUnavailable
+        case 429:
+            AppLogger.api.warning("Places API レート制限超過 (429)")
+            throw AppError.rateLimitExceeded
+        case 401, 403:
+            AppLogger.api.error("Places API 認証エラー (\(http.statusCode))")
+            throw AppError.apiKeyMissing
+        case 400..<500:
+            AppLogger.api.error("Places API クライアントエラー (\(http.statusCode))")
+            throw AppError.unknown(NSError(domain: "Places", code: http.statusCode))
+        case 500...:
+            AppLogger.api.error("Places API サーバーエラー (\(http.statusCode))")
+            throw AppError.networkUnavailable
         default: break
         }
     }
@@ -128,9 +146,14 @@ final class PlacesRepository: StoreRepositoryProtocol {
     private func validateAPIStatus(_ status: String) throws {
         switch status {
         case "OK", "ZERO_RESULTS": break
-        case "REQUEST_DENIED": throw AppError.apiKeyMissing
-        case "OVER_QUERY_LIMIT": throw AppError.rateLimitExceeded
+        case "REQUEST_DENIED":
+            AppLogger.api.error("Places API REQUEST_DENIED")
+            throw AppError.apiKeyMissing
+        case "OVER_QUERY_LIMIT":
+            AppLogger.api.warning("Places API OVER_QUERY_LIMIT")
+            throw AppError.rateLimitExceeded
         default:
+            AppLogger.api.error("Places API 不明なステータス: \(status)")
             throw AppError.unknown(NSError(
                 domain: "Places",
                 code: -1,

--- a/ShishaMap/ViewModels/StoreViewModel.swift
+++ b/ShishaMap/ViewModels/StoreViewModel.swift
@@ -1,5 +1,6 @@
 import CoreLocation
 import Observation
+import OSLog
 import SwiftData
 
 @MainActor
@@ -63,6 +64,7 @@ final class StoreViewModel {
             stores = fetched.map { upsert($0) }
         } catch {
             let appError = AppError(from: error)
+            AppLogger.viewModel.error("fetchNearby失敗: \(appError.errorDescription ?? "")")
             errorMessage = appError.errorDescription
             isRetryable = appError.isRetryable
         }
@@ -80,6 +82,7 @@ final class StoreViewModel {
             await fetchNearby(coordinate: coordinate)
         } catch {
             let appError = AppError(from: error)
+            AppLogger.viewModel.error("searchByArea失敗 query=\(query): \(appError.errorDescription ?? "")")
             errorMessage = appError.errorDescription
             isRetryable = appError.isRetryable
         }


### PR DESCRIPTION
## Summary
- `AppLogger.swift` を新規作成し、`os.Logger` によるカテゴリ別ログ管理を導入（API / ViewModel / Data / Location）
- `PlacesRepository` にAPI通信・HTTPステータス・APIステータスのログを追加
- `StoreViewModel` にエラー発生時のログを追加
- 機密情報（placeID等）は `privacy: .private` 修飾で保護し、リリースビルドでは自動的にマスク
- `.debug` レベルのログはリリースビルドで自動抑制（os_log の標準動作）

## Closes
- Closes #41

## Checklist
- [x] print/NSLog 文がゼロであることを確認
- [x] os.Logger をカテゴリ別に導入
- [x] APIキー・レスポンス内容がログに出力されないことを確認
- [x] リリースビルドでのログレベル設定（os_log の標準動作で .debug 抑制）
- [x] ビルド成功を確認

## Test plan
- [ ] DEBUGビルドでConsole.appからカテゴリ別ログが確認できること
- [ ] Releaseビルドで `.debug` レベルのログが出力されないことを確認
- [ ] API エラー発生時に `.error` / `.warning` レベルのログが記録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)